### PR TITLE
Remove sly cause it is not used in directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 lark-parser
-sly
 llvmlite


### PR DESCRIPTION
I assume it has been replaced by lark.